### PR TITLE
Add the `fast_quick_add` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,5 @@ Use the Add task option to add a task using explicit syntax.
 Use the Quick Add option to add a task using the Todoist smart Quick Add feature, where it recognizes the time, name, and date of the task by reading a sentence you write. 
 
 At any time press the escape key to exit, and press the exit option to go up a menu.
+
+You can pass the argument `fq` to open a `fast_quick_add` and skip the menu page in the system.

--- a/rofi-todoist
+++ b/rofi-todoist
@@ -28,6 +28,10 @@ function quick_add {
 	todoist q "$(echo $quickterm)" && rofi -dmenu -l 0 -mesg 'Task successfully quick added'
 	main_menu
 }
+function fast_quick_add {
+	quickterm=`rofi -dmenu -l 0 -mesg 'Enter Quick Add syntax for new task'`
+	todoist q "$(echo $quickterm)" && rofi -dmenu -l 0 -mesg 'Task successfully quick added'
+}
 function complete_task {
 	if [ "$actionc" = Exit ]; then
 		main_menu # should this go to main menu or just one menu above?
@@ -89,4 +93,10 @@ function main_menu {
 		help_menu
 	fi
 }
-main_menu
+
+if [ "${1}" == "fq" ];
+then
+    fast_quick_add
+else
+    main_menu
+fi


### PR DESCRIPTION
Hello, it's me again :)

This time I created an option to skip the menu if you want jump to a quick add function. The idea here is help that user that have an idea or just find a task and want to add it to its account as fast as possible.

In my scenario, I have two keybinds to call rofi, one opens the full `rofi-todoist` with the menu and other one that open this `fast_quick_add` function, the idea here is not loose focus when I'm working.

Hope you like the idea.